### PR TITLE
exposed variables and operationName on subscription call

### DIFF
--- a/Example/LiveGQLExample/ViewController.swift
+++ b/Example/LiveGQLExample/ViewController.swift
@@ -28,7 +28,7 @@ class ViewController: UIViewController {
     }
     
     @IBAction func subscribe(_ sender: Any) {
-        gql.subscribe(graphql: "subscription {feedbackAdded {id, text}}", identifier: "feed")
+        gql.subscribe(graphql: "subscription {feedbackAdded {id, text}}", variables:nil, operationName: nil, identifier: "feed")
     }
     
     @IBAction func unsubscribe(_ sender: Any) {

--- a/Source/Classes/LiveGQL.swift
+++ b/Source/Classes/LiveGQL.swift
@@ -91,11 +91,11 @@ open class LiveGQL {
         }
     }
     
-    public func subscribe(graphql query: String, identifier: String) {
+    public func subscribe(graphql query: String, variables: [String:String]?, operationName: String?, identifier: String) {
         let unserializedMessage = OperationMessage(
             payload: Payload(query: query,
-                             variables: nil,
-                             operationName: nil),
+                             variables: variables,
+                             operationName: operationName),
             id: identifier,
             type: MessageTypes.GQL_START.rawValue
         )

--- a/Source/Classes/PayloadMessages.swift
+++ b/Source/Classes/PayloadMessages.swift
@@ -22,7 +22,7 @@ struct InitOperationMessage: JSONSerializable {
 
 struct Payload: JSONSerializable {
     let query: String?
-    let variables: String?
+    let variables: [String: String]?
     let operationName: String?
 }
 


### PR DESCRIPTION
Hi,
I made this small change to expose the variables and operationName fields on subscriptions. I use these, as they allow for a standardised library of subscriptions that you can then select operations from. I hope this is useful!
Duncan